### PR TITLE
Set animateChanges on observer during initialisation

### DIFF
--- a/Source/Collection/CollectionFetchedResultsObserver.swift
+++ b/Source/Collection/CollectionFetchedResultsObserver.swift
@@ -12,9 +12,9 @@ final class CollectionFetchedResultsObserver<ResultType: NSFetchRequestResult>: 
 	private var shouldReloadView = false
 	private weak var view: UICollectionView?
 
-	init(controller: NSFetchedResultsController<ResultType>, view: UICollectionView, delegate: FetchedResultsObserverDelegate) {
+	init(controller: NSFetchedResultsController<ResultType>, view: UICollectionView, delegate: FetchedResultsObserverDelegate, animateChanges: Bool) {
 		self.view = view
-		super.init(controller: controller, delegate: delegate)
+		super.init(controller: controller, delegate: delegate, animateChanges: animateChanges)
 	}
 
 	// MARK: - NSFetchedResultsControllerDelegate

--- a/Source/Collection/FetchedCollectionDataSource.swift
+++ b/Source/Collection/FetchedCollectionDataSource.swift
@@ -29,12 +29,10 @@ public final class FetchedCollectionDataSource<DelegateType: FetchedCollectionDa
 
 	public init(controller: NSFetchedResultsController<DelegateType.ResultType>, view: UICollectionView, delegate: DelegateType, animateChanges: Bool = true) {
 		dataSource = CollectionDataSource(controller: controller, view: view, delegate: delegate)
-		observer = CollectionFetchedResultsObserver(controller: controller, view: view, delegate: delegate)
+		observer = CollectionFetchedResultsObserver(controller: controller, view: view, delegate: delegate, animateChanges: animateChanges)
 		super.init(controller: controller)
 
 		dataSource.finishSetup()
-
-		observer.animateChanges = animateChanges
 		observer.finishSetup()
 	}
 

--- a/Source/Collection/FetchedCollectionDataSource.swift
+++ b/Source/Collection/FetchedCollectionDataSource.swift
@@ -33,6 +33,8 @@ public final class FetchedCollectionDataSource<DelegateType: FetchedCollectionDa
 		super.init(controller: controller)
 
 		dataSource.finishSetup()
+
+		observer.animateChanges = animateChanges
 		observer.finishSetup()
 	}
 

--- a/Source/FetchedResultsObserver.swift
+++ b/Source/FetchedResultsObserver.swift
@@ -11,14 +11,15 @@ class FetchedResultsObserver<ResultType: NSFetchRequestResult>: NSObject, NSFetc
 	let controller: NSFetchedResultsController<ResultType>
 	weak var delegate: FetchedResultsObserverDelegate?
 	lazy var changes = FetchedChanges()
-	var animateChanges = true
 	var isVisible = true
+	var animateChanges: Bool
 
 	private var monitor: LifecycleBehaviorViewController?
 
-	init(controller: NSFetchedResultsController<ResultType>, delegate: FetchedResultsObserverDelegate) {
+	init(controller: NSFetchedResultsController<ResultType>, delegate: FetchedResultsObserverDelegate, animateChanges: Bool) {
 		self.controller = controller
 		self.delegate = delegate
+		self.animateChanges = animateChanges
 		super.init()
 	}
 

--- a/Source/FetchedResultsObserver.swift
+++ b/Source/FetchedResultsObserver.swift
@@ -11,8 +11,8 @@ class FetchedResultsObserver<ResultType: NSFetchRequestResult>: NSObject, NSFetc
 	let controller: NSFetchedResultsController<ResultType>
 	weak var delegate: FetchedResultsObserverDelegate?
 	lazy var changes = FetchedChanges()
-	var isVisible = true
 	var animateChanges: Bool
+	private(set) var isVisible = true
 
 	private var monitor: LifecycleBehaviorViewController?
 

--- a/Source/Table/FetchedTableDataSource.swift
+++ b/Source/Table/FetchedTableDataSource.swift
@@ -38,12 +38,10 @@ public final class FetchedTableDataSource<DelegateType: FetchedTableDataSourceDe
 
 	public init(controller: NSFetchedResultsController<DelegateType.ResultType>, view: UITableView, delegate: DelegateType, animateChanges: Bool = true) {
 		dataSource = TableDataSource(controller: controller, view: view, delegate: delegate)
-		observer = TableFetchedResultsObserver(controller: controller, view: view, delegate: delegate)
+		observer = TableFetchedResultsObserver(controller: controller, view: view, delegate: delegate, animateChanges: animateChanges)
 		super.init(controller: controller)
 
 		dataSource.finishSetup()
-
-		observer.animateChanges = animateChanges
 		observer.finishSetup()
 	}
 

--- a/Source/Table/FetchedTableDataSource.swift
+++ b/Source/Table/FetchedTableDataSource.swift
@@ -42,6 +42,8 @@ public final class FetchedTableDataSource<DelegateType: FetchedTableDataSourceDe
 		super.init(controller: controller)
 
 		dataSource.finishSetup()
+
+		observer.animateChanges = animateChanges
 		observer.finishSetup()
 	}
 

--- a/Source/Table/TableFetchedResultsObserver.swift
+++ b/Source/Table/TableFetchedResultsObserver.swift
@@ -12,9 +12,9 @@ final class TableFetchedResultsObserver<ResultType: NSFetchRequestResult>: Fetch
 	var animations: [NSFetchedResultsChangeType: UITableView.RowAnimation] = [:]
 	private weak var view: UITableView?
 
-	init(controller: NSFetchedResultsController<ResultType>, view: UITableView, delegate: FetchedResultsObserverDelegate) {
+	init(controller: NSFetchedResultsController<ResultType>, view: UITableView, delegate: FetchedResultsObserverDelegate, animateChanges: Bool) {
 		self.view = view
-		super.init(controller: controller, delegate: delegate)
+		super.init(controller: controller, delegate: delegate, animateChanges: animateChanges)
 	}
 
 	// MARK: - NSFetchedResultsControllerDelegate


### PR DESCRIPTION
The `animateChanges` parameter that was passed to the fetched data source during initialisation was never used. This pull request fixes that by passing `animateChanges` to the `observer`.