### PR TITLE
fix compilation errors

### DIFF
--- a/Source/Collection/CollectionDataSource.swift
+++ b/Source/Collection/CollectionDataSource.swift
@@ -59,12 +59,12 @@ final class CollectionDataSource<ResultType: NSFetchRequestResult>: DataSource<R
 		delegate?.collectionView?(collectionView, moveItemAt: sourceIndexPath, to: destinationIndexPath)
 	}
 
-	@available(iOS 14.0, *)
+	@available(iOS 9.0, *)
 	func indexTitles(for collectionView: UICollectionView) -> [String]? {
 		return delegate?.indexTitles?(for: collectionView)
 	}
 
-	@available(iOS 14.0, *)
+	@available(iOS 9.0, *)
 	func collectionView(_ collectionView: UICollectionView, indexPathForIndexTitle title: String, at index: Int) -> IndexPath {
 		delegate?.collectionView?(collectionView, indexPathForIndexTitle: title, at: index) ?? IndexPath()
 	}


### PR DESCRIPTION
- protocol `UICollectionViewDataSource` requires `indexTitles(for:)` to be available in iOS 9.0.0 and newer
- protocol `UICollectionViewDataSource` requires `collectionView(_:indexPathForIndexTitle:at:)` to be available in iOS 9.0.0 and newer

![Screenshot 2021-04-28 at 09 11 48](https://user-images.githubusercontent.com/1745504/116363253-3acfd780-a803-11eb-9cb4-a605ed0846e4.png)
